### PR TITLE
兼容标准Clash SSR订阅

### DIFF
--- a/app/Components/Client/Clash.php
+++ b/app/Components/Client/Clash.php
@@ -33,9 +33,11 @@ class Clash
             'password' => $server['passwd'],
             'cipher' => $server['method'],
             'obfs' => $server['obfs'],
-            'obfsparam' => $server['obfs_param'],
             'protocol' => $server['protocol'],
+            'obfsparam' => $server['obfs_param'],
             'protocolparam' => $server['protocol_param'],
+            'obfs-param' => $server['obfs_param'],
+            'protocol-param' => $server['protocol_param'],
             'udp' => $server['udp'],
         ];
     }


### PR DESCRIPTION
看了旧的格式是适配的ClashR，ClashR似乎已经没有在维护了，加上兼容标准Clash。
已测试在Clash能正常使用，未测试在ClashR上新配置是否会导致报错。